### PR TITLE
Content-length byte number fix

### DIFF
--- a/Wkhtmltopdf.php
+++ b/Wkhtmltopdf.php
@@ -641,7 +641,7 @@ class Wkhtmltopdf
                     header("Content-Type: application/pdf", false);
                     header('Content-Disposition: attachment; filename="' . basename($filename) .'";');
                     header("Content-Transfer-Encoding: binary");
-                    header("Content-Length: " . mb_strlen($result));
+                    header("Content-Length: " . strlen($result));
                     echo $result;
                     $filepath = $this->getFilePath();
                     if (!empty($filepath))
@@ -662,7 +662,7 @@ class Wkhtmltopdf
                     header("Pragme: public");
                     header("Expires: Sat, 26 Jul 1997 05:00:00 GMT");
                     header("Last-Modified: " . gmdate('D, d m Y H:i:s') . " GMT");
-                    header("Content-Length: " . mb_strlen($result));
+                    header("Content-Length: " . strlen($result));
                     header('Content-Disposition: inline; filename="' . basename($filename) .'";');
                     echo $result;
                     $filepath = $this->getFilePath();


### PR DESCRIPTION
The content-length HTTP header specifies number of bytes, not number of symbols. So we should be using strlen, not mb_strlen.

This should take care of this issue https://github.com/aur1mas/Wkhtmltopdf/issues/10
