### PR TITLE
Remove requirement for --title option

### DIFF
--- a/Wkhtmltopdf.php
+++ b/Wkhtmltopdf.php
@@ -458,7 +458,6 @@ class Wkhtmltopdf
             return $this->_title;
         }
 
-        throw new Exception("Title is not set");
     }
 
     /**
@@ -557,7 +556,7 @@ class Wkhtmltopdf
         $command .= (mb_strlen($this->getUsername()) > 0) ? " --username " . $this->getUsername() . "" : "";
         $command .= (mb_strlen($this->getFooterHtml()) > 0) ? " --margin-bottom 20 --footer-html \"" . $this->getFooterHtml() . "\"" : "";
 
-        $command .= ' --title "' . $this->getTitle() . '"';
+        $command .= ($this->getTitle()) ? ' --title "' . $this->getTitle() . '"' : '';
         $command .= ' "%input%"';
         $command .= " -";
 


### PR DESCRIPTION
It doesn't look like `--title` is supported anymore for `wkhtmltopdf`.  Having it required breaks the call to the `wkhtmltopdf` bin

This removes the exception throw and checks existence before appending to command string.
