### PR TITLE
Fix deadlock while reading/writing wkhtmltopdf pipes

### DIFF
--- a/Wkhtmltopdf.php
+++ b/Wkhtmltopdf.php
@@ -170,14 +170,62 @@ class Wkhtmltopdf
         $result = array('stdout' => '', 'stderr' => '', 'return' => '');
 
         $proc = proc_open($cmd, array(0 => array('pipe', 'r'), 1 => array('pipe', 'w'), 2 => array('pipe', 'w')), $pipes);
-        fwrite($pipes[0], $input);
-        fclose($pipes[0]);
+        /**
+         * We need to asynchronously process streams, as simple sequential stream_get_contents() risks deadlocking if the 2nd pipe's OS pipe buffer fills up before the 1st is fully consumed.
+         * The input is probably subject to the same risk.
+         */
+        foreach ($pipes as $pipe) {
+            stream_set_blocking($pipe, 0);
+        }
 
-        $result['stdout'] = stream_get_contents($pipes[1]);
-        fclose($pipes[1]);
+        $indexPipes = function(array $pipes) { return array_combine(array_map('intval', $pipes), $pipes); };
+        $allWritables = $indexPipes(array($pipes[0]));
+        $allReadables = $indexPipes(array($pipes[1], $pipes[2]));
+        $readablesNames = array((int)$pipes[1] => 'stdout', (int)$pipes[2] => 'stderr');
+        do {
+            $readables = $allReadables;
+            $writables = $allWritables;
+            $exceptables = null;
+            $selectTime = microtime(true);
+            $nStreams = stream_select($readables, $writables, $exceptables, null, null);
+            $selectTime = microtime(true) - $selectTime;
+            if ($nStreams === false) {
+                throw new \Exception('Error reading/writing to WKHTMLTOPDF');
+            }
 
-        $result['stderr'] = stream_get_contents($pipes[2]);
-        fclose($pipes[2]);
+            foreach ($writables as $writable) {
+                $nBytes = fwrite($writable, $input);
+                if ($nBytes === false) {
+                    throw new \Exception('Error writing to WKHTMLTOPDF');
+                }
+
+                if ($nBytes == strlen($input)) {
+                    fclose($writable);
+                    unset($allWritables[(int)$writable]);
+                    $input = '';
+                } else {
+                    $input = substr($input, $nBytes);
+                }
+            }
+
+            if (count($readables) > 0) {
+                if ($selectTime < 30e3) {
+                    usleep(30e3 - $selectTime); // up to 30ms padding, so we don't burn so much time/CPU reading just 1 byte at a time.
+                }
+                foreach ($readables as $readable) {
+                    $in = fread($readable, 0x10000);
+                    if ($in === false) {
+                        throw new \Exception('Error reading from WKHTMLTOPDF '.$readablesNames[$readable]);
+                    }
+                    $result[$readablesNames[(int)$readable]] .= $in;
+
+                    if (feof($readable)) {
+                        fclose($readable);
+                        unset($allReadables[(int)$readable]);
+                    }
+                }
+            }
+        } while (count($allReadables) > 0 || count($allWritables) > 0);
 
         $result['return'] = proc_close($proc);
 


### PR DESCRIPTION
Fixes #25.

Honestly it feels a bit over-engineered, but I think it has to be this complex to be robust in all situations.  Here is my testcase:

```php
<?php

ini_set('display_errors', true);
require(__DIR__.'/Wkhtmltopdf.php');

srand(787830204305);
// Generate a bunch of random (uncompressable, as the PDF is usually compressed) text over many
// pages, which will fill up the stderr pipe buffer before stdout is fully read.
// I'm not sure how to trigger it more naturally, but I think certain complex but realistic layouts trigger this.
$html = '';
for ($i = 0; $i < 1e5; $i++) {
	$html .= chr(rand(0x20, 0x7e)).'<br>';
}

$wk = new Wkhtmltopdf(array(
	'html' => $html,
	'orientation' => Wkhtmltopdf::ORIENTATION_PORTRAIT,
	'path' => '/tmp',
));

$wk->output(Wkhtmltopdf::MODE_SAVE, 'test.pdf');
```

Before this patch, on my system (CentOS 6.6) `wkhtmltopdf` will take up most of the CPU for a few seconds, then stop and both php and wkhtmltopdf processes sleep indefinitely.  With the patch, the PDF is successfully generated.